### PR TITLE
Don't require GCC 5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,15 @@ project(xmr-stak-cpu)
 cmake_minimum_required(VERSION 2.8.10)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-        message(FATAL_ERROR "GCC version must be at least 5.1!")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8.1)
+        message(FATAL_ERROR "GCC version must be at least 4.8.1!")
     endif()
 endif()
 
 #SET(CMAKE_VERBOSE_MAKEFILE ON)
-SET(CMAKE_C_FLAGS "-DNDEBUG -march=westmere -O3 -m64")
-SET(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
+SET(C_FLAGS "-DNDEBUG -march=westmere -O3 -m64")
+SET(CMAKE_C_FLAGS "${C_FLAGS} -std=gnu99")
+SET(CMAKE_CXX_FLAGS "${C_FLAGS} -std=c++11")
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "-s")
 SET(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "-s")
 set(EXECUTABLE_OUTPUT_PATH "bin")
@@ -19,5 +20,4 @@ file(GLOB SOURCES "crypto/*.c" "*.cpp")
 
 add_executable(xmr-stak-cpu ${SOURCES})
 target_link_libraries(xmr-stak-cpu pthread)
- 
 


### PR DESCRIPTION
Requiring GCC 4.8.1 is more sensible as that's the first version of GCC that had full C++11 support. Source: https://gcc.gnu.org/projects/cxx-status.html#cxx11.

After this change xmr-stak-cpu compiled just fine with GCC 4.9.4, which is the version I'm using.