### PR TITLE
remove prefetches from cryptonight scratchpad inner loop

### DIFF
--- a/crypto/cryptonight_aesni.c
+++ b/crypto/cryptonight_aesni.c
@@ -245,7 +245,6 @@ void cryptonight_hash_ctx(const void* input, size_t len, void* output, cryptonig
 		_mm_store_si128((__m128i *)&l0[idx0 & 0x1FFFF0], _mm_xor_si128(bx0, cx));
 		idx0 = _mm_cvtsi128_si64(cx);
 		bx0 = cx;
-		_mm_prefetch(&l0[idx0 & 0x1FFFF0], _MM_HINT_T0);
 
 		uint64_t hi, lo, cl, ch;
 		cl = ((uint64_t*)&l0[idx0 & 0x1FFFF0])[0];
@@ -258,7 +257,6 @@ void cryptonight_hash_ctx(const void* input, size_t len, void* output, cryptonig
 		ah0 ^= ch;
 		al0 ^= cl;
 		idx0 = al0;
-		_mm_prefetch(&l0[idx0 & 0x1FFFF0], _MM_HINT_T0);
 	}
 
 	// Optim - 90% time boundary
@@ -304,14 +302,12 @@ void cryptonight_double_hash_ctx(const void* input, size_t len, void* output, cr
 		_mm_store_si128((__m128i *)&l0[idx0 & 0x1FFFF0], _mm_xor_si128(bx0, cx));
 		idx0 = _mm_cvtsi128_si64(cx);
 		bx0 = cx;
-		_mm_prefetch(&l0[idx0 & 0x1FFFF0], _MM_HINT_T0);
 
 		cx = _mm_load_si128((__m128i *)&l1[idx1 & 0x1FFFF0]);
 		cx = _mm_aesenc_si128(cx, ax1);
 		_mm_store_si128((__m128i *)&l1[idx1 & 0x1FFFF0], _mm_xor_si128(bx1, cx));
 		idx1 = _mm_cvtsi128_si64(cx);
 		bx1 = cx;
-		_mm_prefetch(&l1[idx1 & 0x1FFFF0], _MM_HINT_T0);
 
 		uint64_t hi, lo;
 		cx = _mm_load_si128((__m128i *)&l0[idx0 & 0x1FFFF0]);
@@ -320,7 +316,6 @@ void cryptonight_double_hash_ctx(const void* input, size_t len, void* output, cr
 		_mm_store_si128((__m128i*)&l0[idx0 & 0x1FFFF0], ax0);
 		ax0 = _mm_xor_si128(ax0, cx);
 		idx0 = _mm_cvtsi128_si64(ax0);
-		_mm_prefetch(&l0[idx0 & 0x1FFFF0], _MM_HINT_T0);
 
 		cx = _mm_load_si128((__m128i *)&l1[idx1 & 0x1FFFF0]);
 		lo = _umul128(idx1, _mm_cvtsi128_si64(cx), &hi);
@@ -328,7 +323,6 @@ void cryptonight_double_hash_ctx(const void* input, size_t len, void* output, cr
 		_mm_store_si128((__m128i*)&l1[idx1 & 0x1FFFF0], ax1);
 		ax1 = _mm_xor_si128(ax1, cx);
 		idx1 = _mm_cvtsi128_si64(ax1);
-		_mm_prefetch(&l1[idx1 & 0x1FFFF0], _MM_HINT_T0);
 	}
 
 	// Optim - 90% time boundary


### PR DESCRIPTION
I noticed that by removing the `_mm_prefetch` from the CryptoNight scratchpad inner loop I was able to get about a 6% performance increase in H/s in high power mode and a 0.5% increase in H/s in low power mode. 

Below are the results of my tests (Windows 10, i7-5820K overclocked to 4.1 GHz, 6 threads pegged to even cores, large page support enabled)

## High power

### With prefetch
```
HASHRATE REPORT
| ID | 2.5s |  60s |  15m | ID | 2.5s |  60s |  15m |
|  0 | 61.9 | 61.7 | (na) |  1 | 62.5 | 62.4 | (na) |
|  2 | 62.9 | 62.8 | (na) |  3 | 62.6 | 62.5 | (na) |
|  4 | 63.1 | 63.0 | (na) |  5 | 62.8 | 62.7 | (na) |
-----------------------------------------------------
Totals:   375.9 375.1 (na) H/s
Highest:  377.3 H/s
```

### Without prefetch
```
HASHRATE REPORT
| ID | 2.5s |  60s |  15m | ID | 2.5s |  60s |  15m |
|  0 | 65.3 | 64.9 | (na) |  1 | 66.6 | 66.2 | (na) |
|  2 | 67.1 | 66.6 | (na) |  3 | 66.5 | 66.1 | (na) |
|  4 | 66.8 | 66.3 | (na) |  5 | 66.8 | 66.4 | (na) |
-----------------------------------------------------
Totals:   399.1 396.5 (na) H/s
Highest:  399.5 H/s
```
## Low power

### With prefetch
```
HASHRATE REPORT
| ID | 2.5s |  60s |  15m | ID | 2.5s |  60s |  15m |
|  0 | 38.0 | 38.3 | (na) |  1 | 40.3 | 40.4 | (na) |
|  2 | 40.9 | 41.0 | (na) |  3 | 40.1 | 40.2 | (na) |
|  4 | 41.5 | 41.4 | (na) |  5 | 40.6 | 40.5 | (na) |
-----------------------------------------------------
Totals:   241.4 241.8 (na) H/s
Highest:  243.3 H/s
```
### Without prefetch
```
HASHRATE REPORT
| ID | 2.5s |  60s |  15m | ID | 2.5s |  60s |  15m |
|  0 | 38.0 | 38.0 | (na) |  1 | 40.0 | 39.9 | (na) |
|  2 | 41.8 | 41.8 | (na) |  3 | 43.6 | 43.5 | (na) |
|  4 | 41.8 | 41.8 | (na) |  5 | 39.9 | 39.9 | (na) |
-----------------------------------------------------
Totals:   245.2 244.9 (na) H/s
Highest:  245.4 H/s
```

I'm by no means an x86 performance guru but I suspect that since each prefetch is followed immediately by an access to the address being prefetched the instruction is superfluous. Moreover, it may confuse the trained prefetcher of the CPU. However, this may be only the case for my CPUs of my generation. I'd be interested in the results of your tests and if you think that this provides a big enough boost to most users to warrant merging.  