### PR TITLE
Update static flags to fix seg fault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_C_FLAGS "-DNDEBUG -march=westmere -O3 -m64 -s")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
 
 set(CMAKE_EXE_LINKER_FLAGS_RELSEASE "")
-set(CMAKE_EXE_LINKER_FLAGS_STATIC "-static")
+set(CMAKE_EXE_LINKER_FLAGS_STATIC "-static-libgcc -static-libstdc++")
 
 set(EXECUTABLE_OUTPUT_PATH "bin")
 


### PR DESCRIPTION
-static will compile, but causes a segment fault on both build and target. Using the new flags compiles cleanly and runs on both build and target. (Build = debian sid [testing], Target= debian jessie [stable])