### PR TITLE
Unify and parameterize CryptoNight functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_EXE_LINKER_FLAGS_STATIC "-static-libgcc -static-libstdc++")
 
 set(EXECUTABLE_OUTPUT_PATH "bin")
 
-file(GLOB SOURCES "crypto/*.c" "*.cpp")
+file(GLOB SOURCES "crypto/*.c" "crypto/*.cpp" "*.cpp")
 
 add_executable(xmr-stak-cpu ${SOURCES})
 target_link_libraries(xmr-stak-cpu pthread microhttpd)

--- a/crypto/cryptonight_common.cpp
+++ b/crypto/cryptonight_common.cpp
@@ -129,7 +129,7 @@ cryptonight_ctx* cryptonight_alloc_ctx(size_t use_fast_mem, size_t use_mlock, al
 		return ptr;
 	}
 #else
-	ptr->long_state = mmap(0, MEMORY, PROT_READ | PROT_WRITE,
+	ptr->long_state = (uint8_t*)mmap(0, MEMORY, PROT_READ | PROT_WRITE,
 		MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, 0, 0);
 
 	if (ptr->long_state == MAP_FAILED)
@@ -174,15 +174,15 @@ void cryptonight_free_ctx(cryptonight_ctx* ctx)
 
 void cryptonight_hash_ctx(const void* input, size_t len, void* output, cryptonight_ctx* ctx)
 {
-	cryptonight_hash<0x8000, MEMORY, true>(input, len, output, ctx);
+	cryptonight_hash<0x80000, MEMORY, true>(input, len, output, ctx);
 }
 
 void cryptonight_hash_ctx_np(const void* input, size_t len, void* output, cryptonight_ctx* ctx)
 {
-	cryptonight_hash<0x8000, MEMORY, false>(input, len, output, ctx);
+	cryptonight_hash<0x80000, MEMORY, false>(input, len, output, ctx);
 }
 
 void cryptonight_double_hash_ctx(const void*  input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1)
 {
-	cryptonight_double_hash<0x8000, MEMORY, false>(input, len, output, ctx0, ctx1);
+	cryptonight_double_hash<0x80000, MEMORY, false>(input, len, output, ctx0, ctx1);
 }

--- a/xmr-stak-cpu.cbp
+++ b/xmr-stak-cpu.cbp
@@ -92,12 +92,7 @@
 		</Unit>
 		<Unit filename="crypto/c_skein.h" />
 		<Unit filename="crypto/cryptonight.h" />
-		<Unit filename="crypto/cryptonight_aesni.c">
-			<Option compilerVar="CC" />
-		</Unit>
-		<Unit filename="crypto/cryptonight_common.c">
-			<Option compilerVar="CC" />
-		</Unit>
+		<Unit filename="crypto/cryptonight_common.cpp" />
 		<Unit filename="crypto/groestl_tables.h" />
 		<Unit filename="crypto/hash.h" />
 		<Unit filename="crypto/int-util.h" />


### PR DESCRIPTION
The core CryptoNight functions are currently duplicated for the prefetch/no-prefetch condition. This patch unifies and parameterizes these functions; they are now templated with three inputs:

- `ITERATIONS`: the number of iterations of the scratchpad procedure
- `MEM`: the size of the scratchpad
- `PREFETCH`: whether or not the next location of the scratchpad should be prefetched using `_mm_prefetch` (see f59c4d1)

Since the functions are parameterized via compile-time constants there is 0% functional overhead -- the code generated by this patch for the CryptoNight functions should be completely identical to previous releases. In particular the `PREFETCH` `bool` should will compile to `if(true)` and `if(false)` which all compilers translate as simply including/excluding the succeeding scope, which was the only difference between `cryptonight_hash_ctx` and `cryptonight_hash_ctx_np`. By parameterizing `ITERATIONS` and `MEM` it should be trivial to implement the request in issue #25 (although this patch does not directly add this in). 