### PR TITLE
refactor CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,108 @@
 project(xmr-stak-cpu)
 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 3.0.1)
 
+# enforce C++11
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 11)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}" CACHE PATH "install prefix" FORCE)
+endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+# allow user to extent CMAKE_PREFIX_PATH via environment variable
+list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
+
+################################################################################
+# CMake user options
+################################################################################
+
+# gcc 5.1 is the first GNU version without CoW strings
+# https://github.com/fireice-uk/xmr-stak-nvidia/pull/10#issuecomment-290821792
+# If you remove this guard to compile with older gcc versions the miner will produce
+# a high rate of wrong shares.
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
         message(FATAL_ERROR "GCC version must be at least 5.1!")
     endif()
 endif()
 
+set(BUILD_TYPE "Release;Debug")
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
+endif()
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${BUILD_TYPE}")
+
+################################################################################
+# Find PThreads
+################################################################################
+
+find_package(Threads REQUIRED)
+set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+
+################################################################################
+# Find microhttpd
+################################################################################
+
 find_library(MHTD NAMES microhttpd)
 if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
-    message(FATAL_ERROR "libmicrohttpd is required")
+    message(STATUS "microhttpd NOT found: disable http server")
+    add_definitions("-DCONF_NO_HTTPD")
+else()
+    set(LIBS ${LIBS} ${MHTD})
 endif()
 
-find_package(OpenSSL REQUIRED)
+###############################################################################
+# Find OpenSSL
+###############################################################################
+
+find_package(OpenSSL)
 include_directories(${OPENSSL_INCLUDE_DIR})
-
-#set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CONFIGURATION_TYPES "RELEASE;STATIC")
-if("${CMAKE_BUILD_TYPE}" STREQUAL "") 
-    set(CMAKE_BUILD_TYPE RELEASE)
+set(LIBS ${LIBS} ${OPENSSL_LIBRARIES})
+if(NOT OPENSSL_FOUND)
+    add_definitions("-DCONF_NO_TLS")
 endif()
 
-set(CMAKE_C_FLAGS "-DNDEBUG -march=westmere -O3 -m64 -s")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
+################################################################################
+# Compile & Link
+################################################################################
 
-set(CMAKE_EXE_LINKER_FLAGS_RELSEASE "")
-set(CMAKE_EXE_LINKER_FLAGS_STATIC "-static-libgcc -static-libstdc++")
+# activate sse2 and aes-ni
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes")
+
+file(GLOB SRCFILES_CPP "*.cpp" "crypto/*.cpp")
+file(GLOB SRCFILES_C "crypto/*.c")
+
+add_library(xmr-stak-c
+    STATIC
+    ${SRCFILES_C}
+)
+set_property(TARGET xmr-stak-c PROPERTY C_STANDARD 99)
+
+add_executable(xmr-stak-cpu
+    ${SRCFILES_CPP}
+)
 
 set(EXECUTABLE_OUTPUT_PATH "bin")
+target_link_libraries(xmr-stak-cpu xmr-stak-c ${LIBS})
 
-file(GLOB SOURCES "crypto/*.c" "crypto/*.cpp" "*.cpp")
+################################################################################
+# Install
+################################################################################
 
-add_executable(xmr-stak-cpu ${SOURCES})
-target_link_libraries(xmr-stak-cpu pthread microhttpd crypto ssl)
- 
+# do not install the binary if the project and install are equal
+if( NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${PROJECT_BINARY_DIR}" )
+    install(TARGETS xmr-stak-amd
+            RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+endif()
 
+
+# avoid overwrite of user defined settings
+# install `config.txt`if file not exists in `${CMAKE_INSTALL_PREFIX}/bin`
+install(CODE " \
+    if(NOT EXISTS ${CMAKE_INSTALL_PREFIX}/bin/config.txt)\n   \
+        file(INSTALL ${CMAKE_CURRENT_SOURCE_DIR}/config.txt   \
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)\n        \
+    endif()"
+)

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -26,7 +26,10 @@
 #include "jconf.h"
 #include "console.h"
 #include "donate-level.h"
-#include "httpd.h"
+
+#ifndef CONF_NO_HTTPD
+#	include "httpd.h"
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -109,6 +112,7 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+#ifndef CONF_NO_HTTPD
 	if(jconf::inst()->GetHttpdPort() != 0)
 	{
 		if (!httpd::inst()->start_daemon())
@@ -117,6 +121,7 @@ int main(int argc, char *argv[])
 			return 0;
 		}
 	}
+#endif
 
 	printer::inst()->print_str("-------------------------------------------------------------------\n");
 	printer::inst()->print_str("XMR-Stak-CPU mining software, CPU Version.\n");

--- a/httpd.cpp
+++ b/httpd.cpp
@@ -21,6 +21,8 @@
   *
   */
 
+#ifndef CONF_NO_HTTPD
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -141,4 +143,6 @@ bool httpd::start_daemon()
 
 	return true;
 }
+
+#endif
 


### PR DESCRIPTION
close #68

This pull request is in the most parts equal to the cmake changes in [xmr-stak-nvidia](https://github.com/fireice-uk/xmr-stak-nvidia/pull/10)

## Changes

- allow compiling without microhttpd
- allow compiling without OpenSSL
- install `config.txt` with command `make install`

## Tests

- [x] GCC 5.4 compile + runtime
- [x] clang 3.8 compile + runtime