### PR TITLE
allow optional static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${BUILD_TYPE}")
 
+# option to add static libgcc and libstdc++
+option(CMAKE_LINK_STATIC "link as much as possible libraries static" OFF)
+
 ################################################################################
 # Find PThreads
 ################################################################################
@@ -83,6 +86,15 @@ endif()
 
 # activate sse2 and aes-ni
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -maes")
+
+# activate static libgcc and libstdc++ linking
+if(CMAKE_LINK_STATIC)
+    set(BUILD_SHARED_LIBRARIES OFF)
+    set(DL_LIB ${CMAKE_DL_LIBS})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+    set(LIBS "-static-libgcc -static-libstdc++ ${LIBS}")
+endif()
 
 file(GLOB SRCFILES_CPP "*.cpp" "crypto/*.cpp")
 file(GLOB SRCFILES_C "crypto/*.c")
@@ -98,7 +110,7 @@ add_executable(xmr-stak-cpu
 )
 
 set(EXECUTABLE_OUTPUT_PATH "bin")
-target_link_libraries(xmr-stak-cpu xmr-stak-c ${LIBS})
+target_link_libraries(xmr-stak-cpu ${LIBS} xmr-stak-c)
 
 ################################################################################
 # Install

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ lBoYbHZRpcWUfDO8o2y+ZQIs+yzMoJHHBBXB9fsHlwq62PTtzjsEVwB2aq9ABzk=
 
 ### To do a static build for a system without gcc 5.1+
 ```
-    cmake -DCMAKE_BUILD_TYPE=STATIC .
+    cmake -DCMAKE_LINK_STATIC=ON .
     make install
 ```
 Note - cmake caches variables, so if you want to do a dynamic build later you need to specify '-DCMAKE_BUILD_TYPE=RELEASE'
@@ -197,6 +197,8 @@ and install.
 - `CMAKE_INSTALL_PREFIX` install miner to the home folder
   - `cmake . -DCMAKE_INSTALL_PREFIX=$HOME/xmr-stak-cpu`
   - you can find the binary and the `config.txt` file after `make install` in `$HOME/xmr-stak-cpu/bin`
+- `CMAKE_LINK_STATIC` link libgcc and libstdc++ libraries static (default OFF)
+  - disable with `cmake . -DCMAKE_LINK_STATIC=ON`
 -`CMAKE_BUILD_TYPE` set the build type
   - valid options: `Release` or `Debug`
   - you should always keep `Release` for your productive miners


### PR DESCRIPTION
close #75 
This pull request is not adding set all libraries are linked static. The reason for this is that the crypto libraries and microhttpd also use dlopen within the static libraries. I get no full static linked version running.
Therefore this version adds only the support to be independent from gcc5.1+.

## Changes
- add cmake option `CMAKE_LINK_STATIC`
- add missing `CMAKE_C_FLAGS`
- change documentation

## Test
- [x] clang compile
- [x] gcc compile dynamic/static
- [x] run binary builded in ubuntu 16.04 on ubuntu 14.04 with old libc