### PR TITLE
speedup systems without huge memory pages

### DIFF
--- a/crypto/cryptonight_common.cpp
+++ b/crypto/cryptonight_common.cpp
@@ -114,7 +114,8 @@ cryptonight_ctx* cryptonight_alloc_ctx(size_t use_fast_mem, size_t use_mlock, al
 
 	if(use_fast_mem == 0)
 	{
-		ptr->long_state = (uint8_t*)_mm_malloc(MEMORY, 4096);
+		// use 2MiB aligned memory
+		ptr->long_state = (uint8_t*)_mm_malloc(MEMORY, 2*1024*1024);
 		ptr->ctx_info[0] = 0;
 		ptr->ctx_info[1] = 0;
 		return ptr;


### PR DESCRIPTION
Increase the performance for systems without huge memory pages to the performance with huge pages.
Use 2 MiB alignment for memory allocations.

## Performance Overview

cpu | used threads | cache | this pr [hash/s] | version before pr [hash/s] | speedup [%] | system
:---|:------------:|:------------------|:------------------------|:------------|:------------|:----
2 x E5-2630 v3 @ 2.40GHz | 16 | 2x20MiB | 821 | 660 | 24 | ubuntu 14.04 no huge pages
i7-4600U CPU @ 2.10GHz | 2 | 4MiB | 117* | 86 | 36  | ubuntu 16.04 no huge pages

\* equal performace with huge pages