### PR TITLE
`_mulx_u64` without compiler flag `-mbmi2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ endif()
 ################################################################################
 
 # activate sse2, aes-ni and bmi2
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes -mbmi2")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -maes -mbmi2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -maes")
 
 # activate static libgcc and libstdc++ linking
 if(CMAKE_LINK_STATIC)

--- a/crypto/cryptonight_aesni.h
+++ b/crypto/cryptonight_aesni.h
@@ -18,9 +18,9 @@
 #include "cryptonight.h"
 #include <memory.h>
 #include <stdio.h>
+#include "mulx.hpp"
 
 #ifdef __GNUC__
-#include <x86intrin.h>
 static inline uint64_t _umul128(uint64_t a, uint64_t b, uint64_t* hi)
 {
 	unsigned __int128 r = (unsigned __int128)a * (unsigned __int128)b;
@@ -29,8 +29,6 @@ static inline uint64_t _umul128(uint64_t a, uint64_t b, uint64_t* hi)
 }
 
 #define _mm256_set_m128i(v0, v1)  _mm256_insertf128_si256(_mm256_castsi128_si256(v1), (v0), 1)
-#else
-#include <intrin.h>
 #endif // __GNUC__
 
 #if !defined(_LP64) && !defined(_WIN64)
@@ -319,7 +317,7 @@ void cryptonight_hash(const void* input, size_t len, void* output, cryptonight_c
 		ch = ((uint64_t*)&l0[idx0 & 0x1FFFF0])[1];
 
 		if(MULX)
-			lo = _mulx_u64(idx0, cl, (long long unsigned int*)&hi);
+			lo = xmr_stak::mulx_u64(idx0, cl, (long long unsigned int*)&hi);
 		else
 			lo = _umul128(idx0, cl, &hi);
 
@@ -406,7 +404,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 		cx = _mm_load_si128((__m128i *)&l0[idx0 & 0x1FFFF0]);
 
 		if(MULX)
-			lo = _mulx_u64(idx0, _mm_cvtsi128_si64(cx), (long long unsigned int*)&hi);
+			lo = xmr_stak::mulx_u64(idx0, _mm_cvtsi128_si64(cx), (long long unsigned int*)&hi);
 		else
 			lo = _umul128(idx0, _mm_cvtsi128_si64(cx), &hi);
 
@@ -421,7 +419,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 		cx = _mm_load_si128((__m128i *)&l1[idx1 & 0x1FFFF0]);
 
 		if(MULX)
-			lo = _mulx_u64(idx1, _mm_cvtsi128_si64(cx), (long long unsigned int*)&hi);
+			lo = xmr_stak::mulx_u64(idx1, _mm_cvtsi128_si64(cx), (long long unsigned int*)&hi);
 		else
 			lo = _umul128(idx1, _mm_cvtsi128_si64(cx), &hi);
 

--- a/crypto/mulx.hpp
+++ b/crypto/mulx.hpp
@@ -1,0 +1,34 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  */
+
+#pragma once
+
+#ifdef __GNUC__
+#   include <x86intrin.h>
+#else
+#   include <intrin.h>
+#endif // __GNUC__
+
+namespace xmr_stak
+{
+    inline
+    unsigned long long
+    __attribute__((target ("bmi2")))
+    mulx_u64 (unsigned long long x, unsigned long long y, unsigned long long *hi)
+    {
+        return _mulx_u64(x,y,hi);
+    }
+}


### PR DESCRIPTION
The compiler flag `-mbmi2` lift the cpu dependency up to architectures >=Haswell.
To avoid this we only use the gcc/clang intrinsic `_mulx_u64`.

## Changes

- remove compiler flag `mbmi2`
- add new function xmr_stak::mulx_u64

## Tests

- [x] gcc compile & run on system with and without bmi2 support
- [x] clang compile & run on system with and without bmi2 support

## Please to not merge because [my test](https://github.com/fireice-uk/xmr-stak-cpu/issues/78#issuecomment-296316305) showing a slowdown on systems with BMI support

--- closed --- new implementation in #80