### PR TITLE
add optional BMI2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ endif()
 ################################################################################
 
 # activate sse2, aes-ni and bmi2
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes -mbmi2")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -maes -mbmi2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -maes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -maes")
 
 # activate static libgcc and libstdc++ linking
 if(CMAKE_LINK_STATIC)

--- a/crypto/cryptonight_hash.h
+++ b/crypto/cryptonight_hash.h
@@ -1,0 +1,38 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  */
+#pragma once
+
+#include <memory.h>
+#include <stdio.h>
+
+
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+extern void cryptonight_hash_bmi2(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+
+// This lovely creation will do 2 cn hashes at a time. We have plenty of space on silicon
+// to fit temporary vars for two contexts. Function will read len*2 from input and write 64 bytes to output
+// We are still limited by L3 cache, so doubling will only work with CPUs where we have more than 2MB to core (Xeons)
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+extern void cryptonight_double_hash_bmi2(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+extern void cryptonight_hash_sse2(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+
+// This lovely creation will do 2 cn hashes at a time. We have plenty of space on silicon
+// to fit temporary vars for two contexts. Function will read len*2 from input and write 64 bytes to output
+// We are still limited by L3 cache, so doubling will only work with CPUs where we have more than 2MB to core (Xeons)
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+extern void cryptonight_double_hash_sse2(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);

--- a/crypto/cryptonight_hash_bmi2.cpp
+++ b/crypto/cryptonight_hash_bmi2.cpp
@@ -1,0 +1,58 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  */
+
+
+#include "cryptonight.h"
+#include "cryptonight_aesni.h"
+#include "cryptonight_hash.h"
+#include <memory.h>
+#include <stdio.h>
+
+
+
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+void
+#ifdef __GNUC__
+__attribute__((target ("bmi2")))
+#endif
+cryptonight_hash_bmi2(const void* input, size_t len, void* output, cryptonight_ctx* ctx0)
+{
+    cryptonight_hash<ITERATIONS, MEM, SOFT_AES, PREFETCH>(
+       input, len, output, ctx0);
+}
+
+// This lovely creation will do 2 cn hashes at a time. We have plenty of space on silicon
+// to fit temporary vars for two contexts. Function will read len*2 from input and write 64 bytes to output
+// We are still limited by L3 cache, so doubling will only work with CPUs where we have more than 2MB to core (Xeons)
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+#ifdef __GNUC__
+__attribute__((target ("bmi2")))
+#endif
+void cryptonight_double_hash_bmi2(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1)
+{
+    cryptonight_double_hash<ITERATIONS, MEM, SOFT_AES, PREFETCH>(
+        input, len, output, ctx0, ctx1);
+}
+
+
+template void cryptonight_double_hash_bmi2<0x80000, MEMORY, false, false>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_double_hash_bmi2<0x80000, MEMORY, false, true>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_double_hash_bmi2<0x80000, MEMORY, true, false>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_double_hash_bmi2<0x80000, MEMORY, true, true>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_hash_bmi2<0x80000, MEMORY, false, false>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+template void cryptonight_hash_bmi2<0x80000, MEMORY, false, true>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+template void cryptonight_hash_bmi2<0x80000, MEMORY, true, false>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+template void cryptonight_hash_bmi2<0x80000, MEMORY, true, true>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);

--- a/crypto/cryptonight_hash_sse2.cpp
+++ b/crypto/cryptonight_hash_sse2.cpp
@@ -1,0 +1,48 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  */
+
+#include "cryptonight.h"
+#include "cryptonight_aesni.h"
+#include "cryptonight_hash.h"
+#include <memory.h>
+#include <stdio.h>
+
+
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+void cryptonight_hash_sse2(const void* input, size_t len, void* output, cryptonight_ctx* ctx0)
+{
+    cryptonight_hash<ITERATIONS, MEM, SOFT_AES, PREFETCH>(
+       input, len, output, ctx0);
+}
+
+// This lovely creation will do 2 cn hashes at a time. We have plenty of space on silicon
+// to fit temporary vars for two contexts. Function will read len*2 from input and write 64 bytes to output
+// We are still limited by L3 cache, so doubling will only work with CPUs where we have more than 2MB to core (Xeons)
+template<size_t ITERATIONS, size_t MEM, bool SOFT_AES, bool PREFETCH>
+void cryptonight_double_hash_sse2(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1)
+{
+    cryptonight_double_hash<ITERATIONS, MEM, SOFT_AES, PREFETCH>(
+        input, len, output, ctx0, ctx1);
+}
+
+template void cryptonight_double_hash_sse2<0x80000, MEMORY, false, false>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_double_hash_sse2<0x80000, MEMORY, false, true>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_double_hash_sse2<0x80000, MEMORY, true, false>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_double_hash_sse2<0x80000, MEMORY, true, true>(const void* input, size_t len, void* output, cryptonight_ctx* __restrict ctx0, cryptonight_ctx* __restrict ctx1);
+template void cryptonight_hash_sse2<0x80000, MEMORY, false, false>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+template void cryptonight_hash_sse2<0x80000, MEMORY, false, true>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+template void cryptonight_hash_sse2<0x80000, MEMORY, true, false>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+template void cryptonight_hash_sse2<0x80000, MEMORY, true, true>(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);

--- a/jconf.cpp
+++ b/jconf.cpp
@@ -279,7 +279,7 @@ bool jconf::check_cpu_features()
 		printer::inst()->print_msg(L0, "Your CPU doesn't support hardware AES. Don't expect high hashrates.");
 
 	if(bHaveBmi2)
-		printer::inst()->print_msg(L0, "CPU supports BMI2 instructions. Faster multiplication enabled.");
+		printer::inst()->print_msg(L0, "CPU supports BMI2 instructions. Faster bit operations enabled.");
 
 	return bHaveSse2;
 }

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -63,7 +63,8 @@ void thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 #include "executor.h"
 #include "minethd.h"
 #include "jconf.h"
-#include "crypto/cryptonight_aesni.h"
+
+#include "crypto/cryptonight_hash.h"
 
 telemetry::telemetry(size_t iThd)
 {
@@ -338,26 +339,26 @@ void minethd::consume_work()
 	iConsumeCnt++;
 }
 
-minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, bool bMulx)
+minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, bool bHaveBmi2)
 {
 	// We have three independent flag bits in the functions
 	// therefore we will build a binary digit and select the
 	// function as a three digit binary
-	// Digit order SOFT_AES, NO_PREFETCH, MULX
+	// Digit order SOFT_AES, NO_PREFETCH, BMI2
 
 	static const cn_hash_fun func_table[8] = {
-		cryptonight_hash<0x80000, MEMORY, false, false, false>,
-		cryptonight_hash<0x80000, MEMORY, false, false, true>,
-		cryptonight_hash<0x80000, MEMORY, false, true, false>,
-		cryptonight_hash<0x80000, MEMORY, false, true, true>,
-		cryptonight_hash<0x80000, MEMORY, true, false, false>,
-		cryptonight_hash<0x80000, MEMORY, true, false, true>,
-		cryptonight_hash<0x80000, MEMORY, true, true, false>,
-		cryptonight_hash<0x80000, MEMORY, true, true, true>
+		cryptonight_hash_sse2<0x80000, MEMORY, false, false>,
+		cryptonight_hash_bmi2<0x80000, MEMORY, false, false>,
+		cryptonight_hash_sse2<0x80000, MEMORY, false, true>,
+		cryptonight_hash_bmi2<0x80000, MEMORY, false, true>,
+		cryptonight_hash_sse2<0x80000, MEMORY, true, false>,
+		cryptonight_hash_bmi2<0x80000, MEMORY, true, false>,
+		cryptonight_hash_sse2<0x80000, MEMORY, true, true>,
+		cryptonight_hash_bmi2<0x80000, MEMORY, true, true>
 	};
 
 	std::bitset<3> digit;
-	digit.set(0, bMulx);
+	digit.set(0, bHaveBmi2);
 	digit.set(1, !bNoPrefetch);
 	digit.set(2, !bHaveAes);
 
@@ -430,26 +431,26 @@ void minethd::work_main()
 	cryptonight_free_ctx(ctx);
 }
 
-minethd::cn_hash_fun_dbl minethd::func_dbl_selector(bool bHaveAes, bool bNoPrefetch, bool bMulx)
+minethd::cn_hash_fun_dbl minethd::func_dbl_selector(bool bHaveAes, bool bNoPrefetch, bool bHaveBmi2)
 {
 	// We have three independent flag bits in the functions
 	// therefore we will build a binary digit and select the
 	// function as a three digit binary
-	// Digit order SOFT_AES, NO_PREFETCH, MULX
+	// Digit order SOFT_AES, NO_PREFETCH, BMI2
 
 	static const cn_hash_fun_dbl func_table[8] = {
-		cryptonight_double_hash<0x80000, MEMORY, false, false, false>,
-		cryptonight_double_hash<0x80000, MEMORY, false, false, true>,
-		cryptonight_double_hash<0x80000, MEMORY, false, true, false>,
-		cryptonight_double_hash<0x80000, MEMORY, false, true, true>,
-		cryptonight_double_hash<0x80000, MEMORY, true, false, false>,
-		cryptonight_double_hash<0x80000, MEMORY, true, false, true>,
-		cryptonight_double_hash<0x80000, MEMORY, true, true, false>,
-		cryptonight_double_hash<0x80000, MEMORY, true, true, true>
+		cryptonight_double_hash_sse2<0x80000, MEMORY, false, false>,
+		cryptonight_double_hash_bmi2<0x80000, MEMORY, false, false>,
+		cryptonight_double_hash_sse2<0x80000, MEMORY, false, true>,
+		cryptonight_double_hash_bmi2<0x80000, MEMORY, false, true>,
+		cryptonight_double_hash_sse2<0x80000, MEMORY, true, false>,
+		cryptonight_double_hash_bmi2<0x80000, MEMORY, true, false>,
+		cryptonight_double_hash_sse2<0x80000, MEMORY, true, true>,
+		cryptonight_double_hash_bmi2<0x80000, MEMORY, true, true>
 	};
 
 	std::bitset<3> digit;
-	digit.set(0, bMulx);
+	digit.set(0, bHaveBmi2);
 	digit.set(1, !bNoPrefetch);
 	digit.set(2, !bHaveAes);
 


### PR DESCRIPTION
This pull request allows to have a separate bmi2 and sse2 code path for the cryptonight hash function within one binary. This pull request replace the previous in #79

## Changes

- remove compiler flag `-bmi2`
- add `cryptonight_hash_*.cpp` for SSE2 and BMI2
- remove explicit usage of `_mulx_u64`

## Windows

The compiler flag `/arch:AVX2` must be defined only for the file `crypto/cryptonight_hash_bmi2.cpp`.
Right klick on the file and add compile option.

## Test

- [x] linux gcc with and without bmi2 support (from one binary)
- [x] linux clang 4.0 with and without bmi2 support (from one binary)
- [x] windows (only checked on systems without AES and BMI2)

## Performance

equal to the tests in #78 row `dev disabled MULX`