### PR TITLE
disable prefetch by default

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -11,8 +11,7 @@
  *                  consume much less power (as less cores are working), but will max out at around 80-85% of 
  *                  the maximum performance.
  *
- * no_prefetch -    This mode meant for large pages only. It will generate an error if running on slow memory
- *                  Some sytems can gain up to extra 5% here, but sometimes it will have no difference or make
+ * no_prefetch -    Some sytems can gain up to extra 5% here, but sometimes it will have no difference or make
  *                  things slower.
  *
  * affine_to_cpu -  This can be either false (no affinity), or the CPU core number. Note that on hyperthreading 
@@ -22,8 +21,8 @@
  *
  */
 "cpu_threads_conf" : [ 
-	{ "low_power_mode" : false, "no_prefetch" : false, "affine_to_cpu" : 0 },
-	{ "low_power_mode" : false, "no_prefetch" : false, "affine_to_cpu" : 1 },
+	{ "low_power_mode" : false, "no_prefetch" : true, "affine_to_cpu" : 0 },
+	{ "low_power_mode" : false, "no_prefetch" : true, "affine_to_cpu" : 1 },
 ],
 
 /*

--- a/jconf.cpp
+++ b/jconf.cpp
@@ -139,9 +139,9 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 	cfg.bDoubleMode = mode->GetBool();
 	cfg.bNoPrefetch = no_prefetch->GetBool();
 
-	if(!bHaveAes && (cfg.bDoubleMode || cfg.bNoPrefetch))
+	if(!bHaveAes && cfg.bDoubleMode)
 	{
-		printer::inst()->print_msg(L0, "Invalid thread confg - low_power_mode and no_prefetch are unsupported on CPUs without AES-NI.");
+		printer::inst()->print_msg(L0, "Invalid thread confg - low_power_mode are unsupported on CPUs without AES-NI.");
 		return false;
 	}
 


### PR DESCRIPTION
## Changes

- allow to disable prefetch on systems without hardware aes
- set default disable memory prefetch

## Reason to change the default

I tested #80
  - with BMI2 hardware, with AES
    - Intel E5-2630 v3
    - Intel i7-4600U
  - without BMI2 hardware, with AES
    - Intel E5-2609
    - AMD Opteron 627
  - without BMI2, **without** AES
    - Intel E5 750
    - Intel i7 2530QM

and all cpus shows better or equal performance without memory prefetching than with enabled prefetch. We should ship the miner with settings those are achieve a high hash rate by default. Most results are documented in #78 .

@fireice-uk Do you have a system where `no_prefetch : false` is faster?