### PR TITLE
fix console guard

### DIFF
--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -154,13 +154,13 @@ int main(int argc, char *argv[])
 		printer::inst()->open_logfile(jconf::inst()->GetOutputFile());
 
 	executor::inst()->ex_start();
+	
+	using namespace std::chrono;
+	uint64_t lastTime = time_point_cast<milliseconds>(high_resolution_clock::now()).time_since_epoch().count();
 
 	int key;
 	while(true)
 	{
-		using namespace std::chrono;
-		uint64_t time = time_point_cast<milliseconds>(high_resolution_clock::now()).time_since_epoch().count();
-
 		key = get_key();
 
 		switch(key)
@@ -178,11 +178,12 @@ int main(int argc, char *argv[])
 			break;
 		}
 
-		time = time - time_point_cast<milliseconds>(high_resolution_clock::now()).time_since_epoch().count();
+		uint64_t currentTime = time_point_cast<milliseconds>(high_resolution_clock::now()).time_since_epoch().count();
 
 		/* Hard guard to make sure we never get called more than twice per second */
-		if(time < 500)
-			std::this_thread::sleep_for(std::chrono::milliseconds(500 - time));
+		if( currentTime - lastTime < 500)
+			std::this_thread::sleep_for(std::chrono::milliseconds(500));
+		lastTime = currentTime;
 	}
 
 	return 0;


### PR DESCRIPTION
Save time stamp of the last for loop round outside of the loop.

This pull request limits the number of key those can pressed by the user to two per second. 