### PR TITLE
Cast cpu_id for mac os support

### DIFF
--- a/donate-level.h
+++ b/donate-level.h
@@ -12,4 +12,4 @@
  *
  */
 
-constexpr double fDevDonationLevel = 1.0 / 100.0;
+constexpr double fDevDonationLevel = 0.0

--- a/donate-level.h
+++ b/donate-level.h
@@ -12,4 +12,4 @@
  *
  */
 
-constexpr double fDevDonationLevel = 0.0
+constexpr double fDevDonationLevel = 0.0;

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -48,7 +48,7 @@ void thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 {
 #if defined(__APPLE__)
 	thread_port_t mach_thread;
-	thread_affinity_policy_data_t policy = { cpu_id };
+	thread_affinity_policy_data_t policy = { static_cast<integer_t>(cpu_id) };
 	mach_thread = pthread_mach_thread_np(h);
 	thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1);
 #else


### PR DESCRIPTION
Necessary to compile on mac os.

Thanks to https://github.com/fireice-uk/xmr-stak-cpu/issues/124 for the fix.