### PR TITLE
Dev branch with mac fix

### DIFF
--- a/minethd.cpp
+++ b/minethd.cpp
@@ -51,7 +51,7 @@ void thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 {
 #if defined(__APPLE__)
 	thread_port_t mach_thread;
-	thread_affinity_policy_data_t policy = { cpu_id };
+	thread_affinity_policy_data_t policy = { static_cast<integer_t>(cpu_id) };
 	mach_thread = pthread_mach_thread_np(h);
 	thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1);
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
Follow up to https://github.com/fireice-uk/xmr-stak-cpu/pull/142 for mac support.  

This is on Mac OS Sierra 10.2.5 and AppleClang 8.1.0.8020042 as the c compiler.

Fixes #124.