### PR TITLE
Fixes building on Alpine Linux

### DIFF
--- a/socks.h
+++ b/socks.h
@@ -76,7 +76,7 @@ inline void sock_close(SOCKET s)
 inline const char* sock_strerror(char* buf, size_t len)
 {
 	buf[0] = '\0';
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || !defined(_GNU_SOURCE) || !defined(__GLIBC__)
 	strerror_r(errno, buf, len);
 	return buf;
 #else


### PR DESCRIPTION
I found there was an issue with compiling on Alpine linux. 
```
[ 72%] Building CXX object CMakeFiles/xmr-stak-cpu.dir/jpsock.cpp.o
In file included from /xmr-stak-cpu/jpsock.cpp:33:0:
/xmr-stak-cpu/socks.h: In function 'const char* sock_strerror(char*, size_t)':
/xmr-stak-cpu/socks.h:83:19: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
  return strerror_r(errno, buf, len);
         ~~~~~~~~~~^~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/xmr-stak-cpu.dir/build.make:183: CMakeFiles/xmr-stak-cpu.dir/jpsock.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:105: CMakeFiles/xmr-stak-cpu.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

As Alpine does not use GLIBC this line is need well only the `!defined(__GLIBC__)` others are just a bonus.
