### PR TITLE
MinGW fix

### DIFF
--- a/crypto/cryptonight_aesni.h
+++ b/crypto/cryptonight_aesni.h
@@ -21,7 +21,12 @@
 
 #ifdef __GNUC__
 #include <x86intrin.h>
-static inline uint64_t _umul128(uint64_t a, uint64_t b, uint64_t* hi)
+#ifdef __MINGW64__
+   extern "C"
+#else
+   static
+#endif // __MINGW64__
+inline uint64_t _umul128(uint64_t a, uint64_t b, uint64_t* hi)
 {
 	unsigned __int128 r = (unsigned __int128)a * (unsigned __int128)b;
 	*hi = r >> 64;

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -33,7 +33,11 @@
 
 void thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 {
+#ifdef __MINGW64__
+	SetThreadAffinityMask(&h, 1ULL << cpu_id);
+#else
 	SetThreadAffinityMask(h, 1ULL << cpu_id);
+#endif // __MINGW64__
 }
 #else
 #include <pthread.h>


### PR DESCRIPTION
The original PR was 140, I made a mistake squashing and updating @ibroheem's branch therefore I opened a new one (the author of the commit is still @ibroheem)

Fixed issues preventing compilation when using a MinGW-64 GCC toolchain.
These fixes did not deal with linking issues, **only makes sure everything compiles fine on a MinGW-64 GCC.**

Tested with compilers from: https://sourceforge.net/projects/mingw-w64/files/mingw-w64/
You can test base:dev with my dev branch and see whats up.