### PR TITLE
Add appveyor initial file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,27 @@
+# Operating system (build VM template)
+os: Visual Studio 2017
+
+# build platform
+platform: x64
+
+# clone directory
+clone_folder: c:\xmr-stak-cpu
+
+install:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+  - call "%VS150COMNTOOLS%\VsMSBuildCmd.bat"
+#  - mkdir c:\xmr-stak-dep
+#  - curl -fsS https://slproweb.com/download/Win32OpenSSL-1_1_0f.exe -o Win32OpenSSL.exe
+#  - Win32OpenSSL.exe /silent /verysilent /sp- /suppressmsgboxes
+#  - curl -fsS https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.7.zip -o hwloc-win64-build.zip
+#  - 7z x hwloc-win64-build.zip -o"c:\xmr-stak-dep" -y > nul
+#  - curl -fsS http://mirror.reismil.ch/gnu/libmicrohttpd/libmicrohttpd-latest-w32-bin.zip -o libmicrohttpd-w32-bin.zip
+#  - 7z x libmicrohttpd-w32-bin.zip -o"c:\xmr-stak-dep" -y > nul
+  - cd c:\xmr-stak-cpu & mkdir build & cd build
+#  - set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc-win64-build-1.11.7;C:\xmr-stak-dep\libmicrohttpd-0.9.55-w32-bin\x86_64\VS2017\Release-static
+  - cmake -G "Visual Studio 15 2017 Win64" -DOpenSSL_ENABLE=OFF -DHWLOC_ENABLE=OFF -DMICROHTTPD_ENABLE=OFF -T v141,host=x64 ..
+  - msbuild xmr-stak-cpu.sln /p:Configuration=Release
+  - cd bin\Release
+  - copy c:\xmr-stak-dep\hwloc-win64-build-1.11.7\bin\libhwloc-5.dll .
+  - copy c:\xmr-stak-dep\libmicrohttpd-0.9.55-w32-bin\x86_64\VS2017\Release-dll\libmicrohttpd-dll.dll .
+  - xmr-stack-cpu -c ..\..\..\config.txt


### PR DESCRIPTION
Hello guys.

I would like to add the Appveyor CI functionality ( mentioned in #149 ) - which can build + test the source code on windows for every pull request.

I tried to follow the steps for windows build in #161 but I'm getting the error https://ci.appveyor.com/project/ruzickap/xmr-stak-cpu

I'm not a windows guy so I have no idea how to compile the source code using Visual Studio, but if you have time please let me know how to fix it to have this feature enabled in the future.
(Looks like some predefined variables for compilation are missing...)

Thank you...