### PR TITLE
Alpine 3.6 compilation errors

### DIFF
--- a/minethd.cpp
+++ b/minethd.cpp
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <cmath>
 #include <chrono>
+#include <cstring>
 #include <thread>
 #include <bitset>
 #include "console.h"

--- a/socks.h
+++ b/socks.h
@@ -76,7 +76,7 @@ inline void sock_close(SOCKET s)
 inline const char* sock_strerror(char* buf, size_t len)
 {
 	buf[0] = '\0';
-#if defined(__APPLE__)
+#if defined(__APPLE__) || !defined(_GNU_SOURCE) || !defined(__GLIBC__)
 	strerror_r(errno, buf, len);
 	return buf;
 #else


### PR DESCRIPTION
Trying to compile in Alpine 3.6 resulted in errors such as:
```
In file included from /xmr-stak-cpu/jpsock.cpp:33:0:
/xmr-stak-cpu/socks.h: In function 'const char* sock_strerror(char*, size_t)':
/xmr-stak-cpu/socks.h:83:19: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
  return strerror_r(errno, buf, len);
```
and
```
/xmr-stak-cpu/minethd.cpp:56:2: error: 'memset' was not declared in this scope
  CPU_ZERO(&mn);
```

This PR fixes them.

To compile on Alpine 3.6 you need to:
```
# apk update
# apk add make cmake g++ libmicrohttpd-dev openssl-dev
$ cmake .
$ make install
```