### PR TITLE
Compile error on Alpine 3.6

### DIFF
--- a/minethd.cpp
+++ b/minethd.cpp
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <cmath>
 #include <chrono>
+#include <cstring>
 #include <thread>
 #include <bitset>
 #include "console.h"

--- a/socks.h
+++ b/socks.h
@@ -76,7 +76,7 @@ inline void sock_close(SOCKET s)
 inline const char* sock_strerror(char* buf, size_t len)
 {
 	buf[0] = '\0';
-#if defined(__APPLE__)
+#if defined(__APPLE__) || !defined(_GNU_SOURCE) || !defined(__GLIBC__)
 	strerror_r(errno, buf, len);
 	return buf;
 #else


### PR DESCRIPTION
Missing cstring library when compiling with Alpine 3.6