### PR TITLE
Slight keccak optimization

### DIFF
--- a/crypto/c_keccak.c
+++ b/crypto/c_keccak.c
@@ -70,19 +70,60 @@ void keccakf(uint64_t st[25], int rounds)
 		}
 
 		//  Chi
-		for (j = 0; j < 25; j += 5) {
-			bc[0] = st[j    ];
-			bc[1] = st[j + 1];
-			bc[2] = st[j + 2];
-			bc[3] = st[j + 3];
-			bc[4] = st[j + 4];
-			st[j    ] ^= (~bc[1]) & bc[2];
-			st[j + 1] ^= (~bc[2]) & bc[3];
-			st[j + 2] ^= (~bc[3]) & bc[4];
-			st[j + 3] ^= (~bc[4]) & bc[0];
-			st[j + 4] ^= (~bc[0]) & bc[1];
-		}
+		// unrolled loop, where only last iteration is different
+		j = 0;
+		bc[0] = st[j    ];
+		bc[1] = st[j + 1];
 
+		st[j    ] ^= (~st[j + 1]) & st[j + 2];
+		st[j + 1] ^= (~st[j + 2]) & st[j + 3];
+		st[j + 2] ^= (~st[j + 3]) & st[j + 4];
+		st[j + 3] ^= (~st[j + 4]) & bc[0];
+		st[j + 4] ^= (~bc[0]) & bc[1];
+
+		j = 5;
+		bc[0] = st[j    ];
+		bc[1] = st[j + 1];
+
+		st[j    ] ^= (~st[j + 1]) & st[j + 2];
+		st[j + 1] ^= (~st[j + 2]) & st[j + 3];
+		st[j + 2] ^= (~st[j + 3]) & st[j + 4];
+		st[j + 3] ^= (~st[j + 4]) & bc[0];
+		st[j + 4] ^= (~bc[0]) & bc[1];
+
+		j = 10;
+		bc[0] = st[j    ];
+		bc[1] = st[j + 1];
+
+		st[j    ] ^= (~st[j + 1]) & st[j + 2];
+		st[j + 1] ^= (~st[j + 2]) & st[j + 3];
+		st[j + 2] ^= (~st[j + 3]) & st[j + 4];
+		st[j + 3] ^= (~st[j + 4]) & bc[0];
+		st[j + 4] ^= (~bc[0]) & bc[1];
+
+		j = 15;
+		bc[0] = st[j    ];
+		bc[1] = st[j + 1];
+
+		st[j    ] ^= (~st[j + 1]) & st[j + 2];
+		st[j + 1] ^= (~st[j + 2]) & st[j + 3];
+		st[j + 2] ^= (~st[j + 3]) & st[j + 4];
+		st[j + 3] ^= (~st[j + 4]) & bc[0];
+		st[j + 4] ^= (~bc[0]) & bc[1];
+
+		j = 20;
+		bc[0] = st[j    ];
+		bc[1] = st[j + 1];
+		bc[2] = st[j + 2];
+		bc[3] = st[j + 3];
+		bc[4] = st[j + 4];
+
+		st[j    ] ^= (~bc[1]) & bc[2];
+		st[j + 1] ^= (~bc[2]) & bc[3];
+		st[j + 2] ^= (~bc[3]) & bc[4];
+		st[j + 3] ^= (~bc[4]) & bc[0];
+		st[j + 4] ^= (~bc[0]) & bc[1];
+		
 		//  Iota
 		st[0] ^= keccakf_rndc[round];
 	}

--- a/crypto/c_keccak.c
+++ b/crypto/c_keccak.c
@@ -24,18 +24,6 @@ const uint64_t keccakf_rndc[24] =
 	0x8000000000008080, 0x0000000080000001, 0x8000000080008008
 };
 
-const int keccakf_rotc[24] = 
-{
-	1,  3,  6,  10, 15, 21, 28, 36, 45, 55, 2,  14, 
-	27, 41, 56, 8,  25, 43, 62, 18, 39, 61, 20, 44
-};
-
-const int keccakf_piln[24] = 
-{
-	10, 7,  11, 17, 18, 3, 5,  16, 8,  21, 24, 4, 
-	15, 23, 19, 13, 12, 2, 20, 14, 22, 9,  6,  1 
-};
-
 // update the state with given number of rounds
 
 void keccakf(uint64_t st[25], int rounds)
@@ -63,11 +51,30 @@ void keccakf(uint64_t st[25], int rounds)
 
 		// Rho Pi
 		t = st[1];
-		for (i = 0; i < 24; ++i) {
-			bc[0] = st[keccakf_piln[i]];
-			st[keccakf_piln[i]] = ROTL64(t, keccakf_rotc[i]);
-			t = bc[0];
-		}
+		st[ 1] = ROTL64(st[ 6], 44);
+		st[ 6] = ROTL64(st[ 9], 20);
+		st[ 9] = ROTL64(st[22], 61);
+		st[22] = ROTL64(st[14], 39);
+		st[14] = ROTL64(st[20], 18);
+		st[20] = ROTL64(st[ 2], 62);
+		st[ 2] = ROTL64(st[12], 43);
+		st[12] = ROTL64(st[13], 25);
+		st[13] = ROTL64(st[19],  8);
+		st[19] = ROTL64(st[23], 56);
+		st[23] = ROTL64(st[15], 41);
+		st[15] = ROTL64(st[ 4], 27);
+		st[ 4] = ROTL64(st[24], 14);
+		st[24] = ROTL64(st[21],  2);
+		st[21] = ROTL64(st[ 8], 55);
+		st[ 8] = ROTL64(st[16], 45);
+		st[16] = ROTL64(st[ 5], 36);
+		st[ 5] = ROTL64(st[ 3], 28);
+		st[ 3] = ROTL64(st[18], 21);
+		st[18] = ROTL64(st[17], 15);
+		st[17] = ROTL64(st[11], 10);
+		st[11] = ROTL64(st[ 7],  6);
+		st[ 7] = ROTL64(st[10],  3);
+		st[10] = ROTL64(t, 1);
 
 		//  Chi
 		// unrolled loop, where only last iteration is different


### PR DESCRIPTION
I unrolled one of the loops in the `c_keccak.c` file and applied a slight optimization, noticing that one doesn't need to assign variables throughout the loop, just on the last iteration. It seems to have helped bump up the hash power a bit. Note that the highest H/s is higher for the PR than Dev. I repeated the test runs several times, always had an increase in highest H/s for PR than Dev (usually also, in the 2.5s, 60s, etc.).

**PR**
    
    HASHRATE REPORT                             
    | ID | 2.5s |  60s |  15m | ID | 2.5s |  60s |  15m |                                                                                                                        
    |  0 | 55.4 | 54.9 | (na) |  1 | 55.3 | 56.1 | (na) |                                                                                                                        
    -----------------------------------------------------                                                                                                                        
    Totals:   110.7 111.1 (na) H/s                                                                                                                                               
    Highest:  112.9 H/s                                                                                                                                                          
    RESULT REPORT                                                                                                                                                                
    Difficulty       : 29594                                                                                                                                                     
    Good results     : 5 / 5 (100.0 %)                                                                                                                                           
    Avg result time  : 19.4 sec                                                                                                                                                  
    Pool-side hashes : 102778                                                                                                                                                    
                                                                                                                                                                                 
    Top 10 best results found:                                                                                                                                                   
    |  0 |          2164579 |  1 |           413969 |                                                                                                                            
    |  2 |            48412 |  3 |            14799 |                                                                                                                            
    |  4 |             9432 |  5 |                0 |                                                                                                                            
    |  6 |                0 |  7 |                0 |                                                                                                                            
    |  8 |                0 |  9 |                0 |                                       
    
    Error details:                              
    Yay! No errors.

**Dev**

    HASHRATE REPORT                             
    | ID | 2.5s |  60s |  15m | ID | 2.5s |  60s |  15m |
    |  0 | 55.2 | 55.0 | (na) |  1 | 55.1 | 55.9 | (na) |
    -----------------------------------------------------
    Totals:   110.3 110.9 (na) H/s
    Highest:  112.7 H/s
    RESULT REPORT
    Difficulty       : 5210
    Good results     : 3 / 3 (100.0 %)
    Avg result time  : 36.0 sec
    Pool-side hashes : 9852
    
    Top 10 best results found:
    |  0 |            13160 |  1 |             5170 |
    |  2 |             3263 |  3 |                0 |
    |  4 |                0 |  5 |                0 |
    |  6 |                0 |  7 |                0 |
    |  8 |                0 |  9 |                0 |
    
    Error details:
    Yay! No errors.

It might need to be tested on other architectures. I only tested on my processor: Intel(R) Core(TM) i7-4600U CPU @ 2.10GHz. It has 4 cores and 4 MB cache.