### PR TITLE
fix wrong cache method

### DIFF
--- a/autoAdjustHwloc.hpp
+++ b/autoAdjustHwloc.hpp
@@ -111,7 +111,7 @@ private:
 	inline bool isCacheExclusive(hwloc_obj_t obj)
 	{
 		const char* value = hwloc_obj_get_info_by_name(obj, "Inclusive");
-		return value != nullptr && value[0] == '1';
+		return value == nullptr || value[0] != '1';
 	}
 
 	// Top level cache isn't shared with other cores on the same package
@@ -141,7 +141,7 @@ private:
 		}
 
 		size_t cacheSize = obj->attr->cache.size;
-		if(!isCacheExclusive(obj))
+		if(isCacheExclusive(obj))
 		{
 			for(size_t i=0; i < obj->arity; i++)
 			{
@@ -156,7 +156,7 @@ private:
 		cores.reserve(16);
 		findChildrenByType(obj, HWLOC_OBJ_CORE, [&cores](hwloc_obj_t found) { cores.emplace_back(found); } );
 
-		size_t cacheHashes = (cacheSize + hashSize - 1) / hashSize;
+		size_t cacheHashes = (cacheSize + hashSize/2u - 1) / hashSize;
 
 		//Firstly allocate PU 0 of every CORE, then PU 1 etc.
 		size_t pu_id = 0;


### PR DESCRIPTION
- fix wrong implemented method `isCacheExclusive()`
- round up number of hashes if >= 1 MiB cache is available