### PR TITLE
CMake: change GCC to g++ warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 # a high rate of wrong shares.
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-        message(FATAL_ERROR "GCC version must be at least 5.1!")
+        message(FATAL_ERROR "g++ version must be at least 5.1!")
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ xXl2Nm/u3cPP/eQVrZz5H8eACwIv+LL1EV+9uLanWUa+IO5hHr3KElvKNKD6vN0=
     make install
 ```
 
-- GCC version 5.1 or higher is required for full C++11 support. CMake release compile scripts, as well as CodeBlocks build environment for debug builds is included.
+- g++ version 5.1 or higher is required for full C++11 support. CMake release compile scripts, as well as CodeBlocks build environment for debug builds is included.
 
 ### To do a static build for a system without gcc 5.1+
 ```


### PR DESCRIPTION
A common issue is that the user only install gcc in version 5.X but the C++ compiler is still pointing to a older version. To avoid this the README and CMake error message mentioned explicit that g++ >=5.1 is needed. 