### PR TITLE
Randomly choose from all available IP addresses

### DIFF
--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -41,7 +41,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <ctime>
+#include <time.h>
 
 #ifndef CONF_NO_TLS
 #include <openssl/ssl.h>
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 	OpenSSL_add_all_digests();
 #endif
 
-	std::srand(std::time(0));
+	srand(time(0));
 
 	const char* sFilename = "config.txt";
 	bool benchmark_mode = false;

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -41,6 +41,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <ctime>
+
 #ifndef CONF_NO_TLS
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -73,6 +75,8 @@ int main(int argc, char *argv[])
 	SSL_load_error_strings();
 	OpenSSL_add_all_digests();
 #endif
+
+	std::srand(std::time(0));
 
 	const char* sFilename = "config.txt";
 	bool benchmark_mode = false;


### PR DESCRIPTION
This is to avoid getting stuck on the same IP which doesn't work for whatever reason.

pool.supportxmr.com uses DNS for load balancing, and it had issues with xmr-stak miners when one of the servers went down and all xmr-stak miners that were on that server didn't switch to the other working server. This change fixes the bug.