### PR TITLE
merge dev fixes back to master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,23 +9,20 @@ clone_folder: c:\xmr-stak-cpu
 
 install:
   - mkdir c:\xmr-stak-dep
-  - curl -fsS http://slproweb.com/download/Win64OpenSSL-1_0_2L.exe -o Win64OpenSSL.exe
-  - Win64OpenSSL.exe /silent /verysilent /sp- /suppressmsgboxes
-  - curl -fsS https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.7.zip -o hwloc-win64-build.zip
-  - 7z x hwloc-win64-build.zip -o"c:\xmr-stak-dep" -y > nul
-  - curl -fsS http://mirror.reismil.ch/gnu/libmicrohttpd/libmicrohttpd-latest-w32-bin.zip -o libmicrohttpd-w32-bin.zip
-  - 7z x libmicrohttpd-w32-bin.zip -o"c:\xmr-stak-dep" -y > nul
+  - curl -sL https://github.com/fireice-uk/xmr-stak-dep/releases/download/v1/xmr-stak-dep.zip -o xmr-stak-dep.zip
+  - 7z x xmr-stak-dep.zip -o"c:\xmr-stak-dep" -y > nul
 
 build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
   - cd c:\xmr-stak-cpu
-  - set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc-win64-build-1.11.7;C:\xmr-stak-dep\libmicrohttpd-0.9.55-w32-bin\x86_64\VS2017\Release-static;
-  - cmake -G "Visual Studio 15 2017 Win64" -T v141,host=x64 .
+  - mkdir build
+  - cd build
+  - set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc;C:\xmr-stak-dep\libmicrohttpd;C:\xmr-stak-dep\openssl;
+  - cmake -G "Visual Studio 15 2017 Win64" -T v141,host=x64 ..
   - msbuild xmr-stak-cpu.sln /p:Configuration=Release
 
 test_script:
-  - cd c:\xmr-stak-cpu\bin\Release
-  - copy c:\xmr-stak-dep\hwloc-win64-build-1.11.7\bin\libhwloc-5.dll .
-  - copy c:\xmr-stak-dep\libmicrohttpd-0.9.55-w32-bin\x86_64\VS2017\Release-dll\libmicrohttpd-dll.dll .
+  - cd c:\xmr-stak-cpu\build\bin\Release
   - dir
-#  - xmr-stak-cpu.exe -c ..\..\..\config.txt
+  - copy ..\..\..\config.txt .
+#  - xmr-stak-cpu.exe

--- a/WINCOMPILE.md
+++ b/WINCOMPILE.md
@@ -20,22 +20,10 @@
 - tested version: [cmake 3.9](https://cmake.org/files/v3.9/cmake-3.9.0-rc3-win64-x64.msi)
 - during the install choose the option `Add CMake to the system PATH for all users`
 
-### OpenSSL for Win64
+### Dependencies OpenSSL/Hwloc and Microhttpd
 
-- download and install the precompiled binary form [https://slproweb.com/products/Win32OpenSSL.html](https://slproweb.com/products/Win32OpenSSL.html)
-- tested version: [OpenSSL 1.0.2L](https://slproweb.com/download/Win64OpenSSL-1_0_2L.exe)
-
-### Hwloc for Win64
-
-- download the precompiled binary from [https://www.open-mpi.org/software/hwloc/v1.11/](https://www.open-mpi.org/software/hwloc/v1.11/)
-- tested version: [hwloc-win64-build-1.11.7](https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-win64-build-1.11.7.zip)
-- unzip hwloc to `C:\xmr-stak-dep`
-
-### Microhttpd for Win32
-
-- download the precompiled binary from [http://ftpmirror.gnu.org/libmicrohttpd/](http://ftpmirror.gnu.org/libmicrohttpd/)
-- tested version: [libmicrohttpd-0.9.55-w32-bin](http://mirror.reismil.ch/gnu/libmicrohttpd/libmicrohttpd-0.9.55-w32-bin.zip)
-- unzip microhttpd to ``C:\xmr-stak-dep`
+- download the precompiled binary from [https://github.com/fireice-uk/xmr-stak-dep/releases/download/v1/xmr-stak-dep.zip](https://github.com/fireice-uk/xmr-stak-dep/releases/download/v1/xmr-stak-dep.zip)
+- unzip all to `C:\xmr-stak-dep`
 
 ### Validate the Dependency Folder
 
@@ -47,109 +35,41 @@
    ```
 - the result should have the same structure
   ```
+    C:\xmr-stak-dep>tree .
+    Folder PATH listing for volume Windows
+    Volume serial number is XX02-XXXX
     C:\XMR-STAK-DEP
-    ├───hwloc-win64-build-1.11.7
-    │   ├───bin
+    ├───hwloc
     │   ├───include
-    │   │   └───hwloc
+    │   │   ├───hwloc
+    │   │   │   └───autogen
+    │   │   └───private
     │   │       └───autogen
-    │   ├───lib
-    │   │   └───pkgconfig
-    │   └───share
-    │       ├───doc
-    │       │   └───hwloc
-    │       ├───hwloc
-    │       └───man
-    │           ├───man1
-    │           ├───man3
-    │           └───man7
-    └───libmicrohttpd-0.9.55-w32-bin
-        ├───x86
-        │   ├───MinGW
-        │   │   ├───shared
-        │   │   │   └───mingw32
-        │   │   │       ├───bin
-        │   │   │       ├───include
-        │   │   │       └───lib
-        │   │   │           └───pkgconfig
-        │   │   ├───shared-xp
-        │   │   │   └───mingw32
-        │   │   │       ├───bin
-        │   │   │       ├───include
-        │   │   │       └───lib
-        │   │   │           └───pkgconfig
-        │   │   ├───static
-        │   │   │   └───mingw32
-        │   │   │       ├───include
-        │   │   │       └───lib
-        │   │   │           └───pkgconfig
-        │   │   └───static-xp
-        │   │       └───mingw32
-        │   │           ├───include
-        │   │           └───lib
-        │   │               └───pkgconfig
-        │   ├───VS2013
-        │   │   ├───Release-dll
-        │   │   ├───Release-dll-xp
-        │   │   ├───Release-static
-        │   │   └───Release-static-xp
-        │   ├───VS2015
-        │   │   ├───Debug-dll
-        │   │   ├───Debug-dll-xp
-        │   │   ├───Debug-static
-        │   │   ├───Debug-static-xp
-        │   │   ├───Release-dll
-        │   │   ├───Release-dll-xp
-        │   │   ├───Release-static
-        │   │   └───Release-static-xp
-        │   └───VS2017
-        │       ├───Debug-dll
-        │       ├───Debug-static
-        │       ├───Release-dll
-        │       └───Release-static
-        └───x86_64
-            ├───MinGW
-            │   ├───shared
-            │   │   └───mingw64
-            │   │       ├───bin
-            │   │       ├───include
-            │   │       └───lib
-            │   │           └───pkgconfig
-            │   └───static
-            │       └───mingw64
-            │           ├───include
-            │           └───lib
-            │               └───pkgconfig
-            ├───VS2013
-            │   ├───Release-dll
-            │   └───Release-static
-            ├───VS2015
-            │   ├───Debug-dll
-            │   ├───Debug-static
-            │   ├───Release-dll
-            │   └───Release-static
-            └───VS2017
-                ├───Debug-dll
-                ├───Debug-static
-                ├───Release-dll
-                └───Release-static
+    │   └───lib
+    ├───libmicrohttpd
+    │   ├───include
+    │   └───lib
+    └───openssl
+        ├───bin
+        ├───include
+        │   └───openssl
+        └───lib
   ```
 
 ## Compile
 
 - download and unzip `xmr-stak-cpu`
-- open a command line `cmd`
+- open the command line terminal `cmd`
 - `cd` to your unzipped source code directory
 - execute the following commands (NOTE: path to VS2017 can be different)
   ```
   "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
-  set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc-win64-build-1.11.7;C:\xmr-stak-dep\libmicrohttpd-0.9.55-w32-bin\x86_64\VS2017\Release-static
+  set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc;C:\xmr-stak-dep\libmicrohttpd;C:\xmr-stak-dep\openssl
   mkdir build
   cd build
   cmake -G "Visual Studio 15 2017 Win64" -T v141,host=x64 ..
   msbuild xmr-stak-cpu.sln /p:Configuration=Release
   cd bin\Release
-  copy C:\xmr-stak-dep\hwloc-win64-build-1.11.7\bin\libhwloc-5.dll .
   copy ..\..\..\config.txt .
   ```
 - customize your `config.txt` file by adding the pool, username and password


### PR DESCRIPTION
@fireice-uk The version number is equal to the last release

- merge back appveyor fix (use precompiled dependencies)
- merge back installation guide for ubuntu 14.04