### PR TITLE
Env variable "MICROHTTPD_ROOT" is ignored by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(MICROHTTPD_ENABLE)
             /usr/local
             /usr
             ENV "PROGRAMFILES(X86)"
-            ENV "HWLOC_ROOT"
+            ENV "MICROHTTPD_ROOT"
         PATH_SUFFIXES
             include)
 


### PR DESCRIPTION
Fixing bug in CMakeLists.txt preventing to pick up microhttpd library root as defined in environment variable "MICROHTTPD_ROOT"
Example: "export MICROHTTPD_ROOT=/opt/gnu/libmicrohttpd-0.9.55" will be ignored without this fix