### PR TITLE
fixed an issue where double thread benchmarking causes EXC_BAD_ACCESS

### DIFF
--- a/minethd.cpp
+++ b/minethd.cpp
@@ -531,7 +531,9 @@ void minethd::double_work_main()
 			iCount += 2;
 
 			*piNonce0 = ++iNonce;
-			*piNonce1 = ++iNonce;
+            if (piNonce1 != nullptr) {
+                *piNonce1 = ++iNonce;
+            }
 
 			hash_fun(bDoubleWorkBlob, oWork.iWorkSize, bDoubleHashOut, ctx0, ctx1);
 


### PR DESCRIPTION
When executing the benchmarking function `do_benchmark()` in _cli-miner.cpp_ it causes `EXC_BAD_ACCESS`.

![screen shot 2017-09-20 at 3 58 16 pm](https://user-images.githubusercontent.com/433270/30671660-f56ba3e8-9e1c-11e7-96e3-a40dedaa89f9.png)

This is because `piNonce1` is created with `nullptr` and then incremented without initializing it with something not null first... (like `piNonce0` is)

This fixes the crash in the benchmark but it likely leads to unwanted behavior. I think it would be better to actually make sure `piNonce1` is initialized before incrementing it...