### PR TITLE
Flush stdout option, solves issue #342

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -152,6 +152,14 @@ null,
 "h_print_time" : 60,
 
 /*
+ * Buffered output control.
+ * When running the miner through a pipe, standard output is buffered. This means that the pipe won't read
+ * each output line immediately. This can cause delays when running in background.
+ * Set this option to true to flush stdout after each line, so it can be read immediately.
+ */
+"flush_stdout": false,
+
+/*
  * Daemon mode
  *
  * If you are running the process in the background and you don't need the keyboard reports, set this to true.

--- a/console.cpp
+++ b/console.cpp
@@ -156,6 +156,7 @@ printer::printer()
 {
 	verbose_level = LINF;
 	logfile = nullptr;
+	b_flush_stdout = false;
 }
 
 bool printer::open_logfile(const char* file)
@@ -193,6 +194,11 @@ void printer::print_msg(verbosity verbose, const char* fmt, ...)
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(buf, stdout);
 
+	if (b_flush_stdout)
+	{
+		fflush(stdout);
+	}
+	
 	if(logfile != nullptr)
 	{
 		fputs(buf, logfile);

--- a/console.h
+++ b/console.h
@@ -29,6 +29,7 @@ public:
 	};
 
 	inline void set_verbose_level(size_t level) { verbose_level = (verbosity)level; }
+	inline void set_flush_stdout(bool status) { b_flush_stdout = status; }
 	void print_msg(verbosity verbose, const char* fmt, ...);
 	void print_str(const char* str);
 	bool open_logfile(const char* file);
@@ -39,5 +40,6 @@ private:
 
 	std::mutex print_mutex;
 	verbosity verbose_level;
+	bool b_flush_stdout;
 	FILE* logfile;
 };

--- a/jconf.cpp
+++ b/jconf.cpp
@@ -47,7 +47,7 @@ using namespace rapidjson;
  */
 enum configEnum { aCpuThreadsConf, sUseSlowMem, bNiceHashMode, bAesOverride,
 	bTlsMode, bTlsSecureAlgo, sTlsFingerprint, sPoolAddr, sWalletAddr, sPoolPwd,
-	iCallTimeout, iNetRetry, iGiveUpLimit, iVerboseLevel, iAutohashTime,
+	iCallTimeout, iNetRetry, iGiveUpLimit, iVerboseLevel, iAutohashTime, bFlushStdout,
 	bDaemonMode, sOutputFile, iHttpdPort, bPreferIpv4 };
 
 struct configVal {
@@ -74,6 +74,7 @@ configVal oConfigValues[] = {
 	{ iGiveUpLimit, "giveup_limit", kNumberType },
 	{ iVerboseLevel, "verbose_level", kNumberType },
 	{ iAutohashTime, "h_print_time", kNumberType },
+	{ bFlushStdout, "flush_stdout", kTrueType},
 	{ bDaemonMode, "daemon_mode", kTrueType },
 	{ sOutputFile, "output_file", kStringType },
 	{ iHttpdPort, "httpd_port", kNumberType },
@@ -462,6 +463,17 @@ bool jconf::parse_config(const char* sFilename)
 
 	if(!bHaveAes)
 		printer::inst()->print_msg(L0, "Your CPU doesn't support hardware AES. Don't expect high hashrates.");
+
+	if (prv->configValues[bFlushStdout]->IsBool())
+	{
+		bool bflush = prv->configValues[bFlushStdout]->GetBool();
+		printer::inst()->set_flush_stdout(bflush);
+		if (bflush)
+		{
+			printer::inst()->print_msg(L0, "Flush stdout forced.");
+		}
+	}
+		
 
 	return true;
 }


### PR DESCRIPTION
Added the option to forcefully flush STDOUT, which may be useful when running the miner through a pipe instead than a shell.
If STDOUT is a shell, it's unbuffered by default.
If STDOUT is a pipe, it's buffered by default.

Solves issue https://github.com/fireice-uk/xmr-stak-cpu/issues/342