### PR TITLE
Extend low_power_mode to do 4 or 5 hashes at the same time.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -2,7 +2,8 @@
  * Thread configuration for each thread. Make sure it matches the number above.
  * low_power_mode - This mode will double the cache usage, and double the single thread performance. It will 
  *                  consume much less power (as less cores are working), but will max out at around 80-85% of 
- *                  the maximum performance.
+ *                  the maximum performance. Also one may set this to 4 or 5 to do 4 or 5 hashes at the same 
+ *                  time. This may improve performance on certain systems.
  *
  * no_prefetch -    Some sytems can gain up to extra 5% here, but sometimes it will have no difference or make
  *                  things slower.

--- a/jconf.cpp
+++ b/jconf.cpp
@@ -134,7 +134,10 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 	if(mode == nullptr || no_prefetch == nullptr || aff == nullptr)
 		return false;
 
-	if(!mode->IsBool() || !no_prefetch->IsBool())
+	if(!mode->IsBool() && !mode->IsNumber())
+		return false;
+
+	if(!no_prefetch->IsBool())
 		return false;
 
 	if(!aff->IsNumber() && !aff->IsBool())
@@ -143,7 +146,15 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 	if(aff->IsNumber() && aff->GetInt64() < 0)
 		return false;
 
-	cfg.bDoubleMode = mode->GetBool();
+	if (mode->IsNumber())
+	{
+		cfg.iMultiple = (int)mode->GetInt64();
+	}
+	else
+	{
+		cfg.iMultiple = mode->GetBool() ? 2 : 1;
+	}
+
 	cfg.bNoPrefetch = no_prefetch->GetBool();
 
 	if(aff->IsNumber())

--- a/jconf.h
+++ b/jconf.h
@@ -14,7 +14,7 @@ public:
 	bool parse_config(const char* sFilename);
 
 	struct thd_cfg {
-		bool bDoubleMode;
+		int iMultiple;
 		bool bNoPrefetch;
 		long long iCpuAff;
 	};

--- a/minethd.h
+++ b/minethd.h
@@ -101,8 +101,10 @@ public:
 private:
 	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*);
 	typedef void (*cn_hash_fun_dbl)(const void*, size_t, void*, cryptonight_ctx* __restrict, cryptonight_ctx* __restrict);
+	typedef void (*cn_hash_fun_quad)(const void*, size_t, void*, cryptonight_ctx* __restrict [4]);
+	typedef void (*cn_hash_fun_pent)(const void*, size_t, void*, cryptonight_ctx* __restrict [5]);
 
-	minethd(miner_work& pWork, size_t iNo, bool double_work, bool no_prefetch, int64_t affinity);
+	minethd(miner_work& pWork, size_t iNo, int iMultiple, bool no_prefetch, int64_t affinity);
 
 	// We use the top 10 bits of the nonce for thread and resume
 	// This allows us to resume up to 128 threads 4 times before
@@ -117,9 +119,13 @@ private:
 
 	static cn_hash_fun func_selector(bool bHaveAes, bool bNoPrefetch);
 	static cn_hash_fun_dbl func_dbl_selector(bool bHaveAes, bool bNoPrefetch);
+	static cn_hash_fun_quad func_quad_selector(bool bHaveAes, bool bNoPrefetch);
+	static cn_hash_fun_pent func_pent_selector(bool bHaveAes, bool bNoPrefetch);
 
 	void work_main();
 	void double_work_main();
+	void quad_work_main();
+	void pent_work_main();
 	void consume_work();
 	uint32_t* prep_double_work(uint8_t bDoubleWorkBlob[sizeof(miner_work::bWorkBlob) * 2]);
 


### PR DESCRIPTION
Set low_power_mode to values "4" or "5" to enable these new modes. They
seem to perform significantly better than the existing single and
double hashing modes, but the result may vary on different devices.