### PR TITLE
Fix indent on hash rate report.

### DIFF
--- a/executor.cpp
+++ b/executor.cpp
@@ -481,7 +481,10 @@ inline const char* hps_format(double h, char* buf, size_t l)
 {
 	if(std::isnormal(h) || h == 0.0)
 	{
-		snprintf(buf, l, " %03.1f", h);
+                if(h < 10.0)
+		    snprintf(buf, l, "  %03.1f", h);
+                else
+		    snprintf(buf, l, " %04.1f", h);
 		return buf;
 	}
 	else


### PR DESCRIPTION
Before:
<img width="457" alt="screen shot 2017-11-15 at 1 31 35 am" src="https://user-images.githubusercontent.com/1990056/32828886-3d6652de-c9a5-11e7-8113-345da3a1fdde.png">

After:
<img width="436" alt="screen shot 2017-11-15 at 1 36 02 am" src="https://user-images.githubusercontent.com/1990056/32828928-601ccb1e-c9a5-11e7-9bd5-c58b65079ae6.png">
